### PR TITLE
Use gradle-versions-plugin to check for dependency updates.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
  - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:2.0.0.RELEASE")
+        classpath("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     }
 }
 
@@ -14,6 +15,7 @@ buildscript {
 group = 'opacapi'
 version = '1.0-SNAPSHOT'
 
+apply from: 'gradle/gradle-versions.gradle'
 apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'application'

--- a/gradle/gradle-versions.gradle
+++ b/gradle/gradle-versions.gradle
@@ -1,0 +1,19 @@
+// Gradle Versions Plugin
+
+apply plugin: "com.github.ben-manes.versions"
+
+dependencyUpdates {
+
+    def isNonStable = { String version ->
+        def stableKeyword = ["RELEASE", "FINAL", "GA"].any {
+            qualifier -> version.toUpperCase().contains(qualifier)
+        }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+
+    rejectVersionIf {
+        isNonStable(it.candidate.version)
+    }
+
+}


### PR DESCRIPTION
# Description
+ This allows to manually check for new versions of the project's dependencies from time to time.
+ This plugin adds the `dependencyUpdates` Gradle task.
+ Version 0.27.0 is used because it is the last version being compatible with the Gradle version used in this project.
+ Plugin website: https://github.com/ben-manes/gradle-versions-plugin

# Command + example output

``` bash
$ ./gradlew dependencyUpdates
```

```
------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies have later milestone versions:
 - com.github.ben-manes:gradle-versions-plugin [0.27.0 -> 0.33.0]
     https://github.com/ben-manes/gradle-versions-plugin
 - net.opacapp:libopac [5.2.5 -> 6.2.7]
 - org.bouncycastle:bcprov-jdk16 [1.45 -> 1.46]
     http://www.bouncycastle.org/java.html
 - org.junit.jupiter:junit-jupiter-api [5.0.2 -> 5.7.0]
     https://junit.org/junit5/
 - org.springframework.boot:spring-boot-gradle-plugin [2.0.0.RELEASE -> 2.3.4.RELEASE]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-test [2.0.0.RELEASE -> 2.3.4.RELEASE]
     https://spring.io/projects/spring-boot
 - org.springframework.boot:spring-boot-starter-web [2.0.0.RELEASE -> 2.3.4.RELEASE]
     https://spring.io/projects/spring-boot

Gradle current updates:
 - Gradle: [4.6 -> 6.6.1]

Generated report file build/dependencyUpdates/report.txt
```